### PR TITLE
chore(deps): pin docker base image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM renovate/renovate
+FROM renovate/renovate:19
 
 LABEL version="1.0.0"
 LABEL maintainer="Julien Tanay"
@@ -12,4 +12,3 @@ LABEL repository = "https://github.com/Djiit/action-renovate"
 LABEL homepage = "https://github.com/Djiit/action-renovate"
 
 ENV GITHUB_ACTION_NAME="Renovate"
-


### PR DESCRIPTION
- Pinned docker base image version to `19`. Setup Renovate to automatically update to last version.